### PR TITLE
Sistemato spada e piattaforme

### DIFF
--- a/The_Messenger/Crystal.cpp
+++ b/The_Messenger/Crystal.cpp
@@ -2,6 +2,7 @@
 #include "StaticObject.h"
 #include "SpriteFactory.h"
 #include "Sword.h"
+#include "Mario.h"
 
 using namespace agp;
 
@@ -17,17 +18,11 @@ Crystal::Crystal(Scene* scene, const RectF& rect, int layer) :
 	_sprite = SpriteFactory::instance()->get("crystal");
 
 	_yGravityForce = 0;
-	//_xMoveForce = 3.f;
-	//_xVelMax = 3;
-	//move(Direction::RIGHT);
 }
 
 void Crystal::update(float dt)
 {
-	//move(Direction::RIGHT);
-	//_sprite = SpriteFactory::instance()->get("ranged_kappa_stand");
 	CollidableObject::update(dt);
-
 }
 
 bool Crystal::collision(CollidableObject* with, bool begin, Direction fromDir) {
@@ -35,11 +30,9 @@ bool Crystal::collision(CollidableObject* with, bool begin, Direction fromDir) {
 	Sword* sword = dynamic_cast<Sword*>(with);
 
 	if (sword != nullptr) {
-		std::cout << "ninja colpisce il fregno" << std::endl;
 		this->kill();
 		return true;
 	}
-	else if (sword == nullptr)
-		std::cout << "prova cazzo" << std::endl;
-	return false;
+	else
+		return false;
 }

--- a/The_Messenger/LevelLoader.cpp
+++ b/The_Messenger/LevelLoader.cpp
@@ -84,10 +84,10 @@ Scene* LevelLoader::load(const std::string& name)
 		world->setBackgroundColor(Color(92, 148, 252));
 
 		// terrain
-		new StaticObject(world, RectF(0, -13, 162, 19),  spriteLoader->get("terrain"), -1);
+		new StaticObject(world, RectF(0, -13, 162, 19),  spriteLoader->get("terrain"), -2);
 	
 		// Enemies 
-		//RangedKappa* rKappa1 = new RangedKappa(world, PointF(10, 1));
+		RangedKappa* rKappa1 = new RangedKappa(world, PointF(10, 1));
 		//RangedKappa* rKappa2 = new RangedKappa(world, PointF(13, 1));
 		//Bat* bat1 = new Bat(world, PointF(10, 0));
 		//GreenKappa* gKappa1 = new GreenKappa(world, PointF(10, 1)); 

--- a/The_Messenger/Mario.cpp
+++ b/The_Messenger/Mario.cpp
@@ -104,8 +104,13 @@ void Mario::update(float dt)
 	if (_fall || _rise || _ball)
 		climb_stationary();
 
+
 	if (_fall && _wantsToClimb)
 		_wantsToClimb = false;
+	
+	// Cosi' il coso quando è basso non può camminare con il collider basso
+	if (_crouch && _walking)
+		_crouch = false;
 
 	// animations
 	if (_dying)
@@ -282,19 +287,14 @@ void Mario::attack()
 	schedule("attacking_off", 0.33f, [this]()
 	{
 		//Disattivazione dell'attacco
-		if (_runningAttack)
-			_runningAttack = false;
-		else if (_jumpingAttack)
-			_jumpingAttack = false;
-		else if (_crouchAttack)
-			_crouchAttack = false;
-		else {
-			_standingAttack1 = false;
-		}
-
-		_scene->killObject(_sword);
-		_sword = nullptr;
+		_runningAttack = false;
+		_jumpingAttack = false;
+		_crouchAttack = false;
+		_standingAttack1 = false;
 		});
+
+	_scene->killObject(_sword);
+	_sword = nullptr;
 }
 
 void Mario::die()

--- a/The_Messenger/StaticLift.cpp
+++ b/The_Messenger/StaticLift.cpp
@@ -32,7 +32,7 @@ void StaticLift::update(float dt) {
 bool StaticLift::collision(CollidableObject* with, bool begin, Direction fromDir) {
 	Mario* mario = dynamic_cast<Mario*>(with);
 
-	if (mario && fromDir == Direction::DOWN) {
+	if (mario && (fromDir == Direction::DOWN || fromDir == Direction::LEFT || fromDir == Direction::RIGHT)) {
 		_compenetrable = true; 
 
 		schedule("compenetrable_off", 0.4f, [this] {

--- a/The_Messenger/Sword.cpp
+++ b/The_Messenger/Sword.cpp
@@ -13,20 +13,20 @@
 #include "Scene.h"
 #include "AnimatedSprite.h"
 #include "Enemy.h"
+#include "Crystal.h"
 
 using namespace agp;
 
 Sword::Sword(Mario* mario)
-	: DynamicObject(mario->scene(), RectF(mario->pos().x, mario->pos().y, 2, 2), nullptr, mario->layer() - 1)
+	: DynamicObject(mario->scene(), RectF(mario->pos().x, mario->pos().y, 5, 3), nullptr, mario->layer() - 1)
 {
-	_fit = false;
 	_link = mario;
 	_facingDir = _link->facingDir();
 	_yGravityForce = 0;
 	_CCD = false;
 
 	// Inizializzazione parametri del collider della spada
-	_collider.adjust(1.3, 0.8, 1.5f, -0.2f);
+	_collider = { 1, 0.8, 3, 2 };
 }
 
 void Sword::update(float dt)
@@ -46,7 +46,13 @@ void Sword::update(float dt)
 
 bool Sword::collidableWith(CollidableObject* obj)
 {
-	return dynamic_cast<Enemy*>(obj);
+	Enemy* enemy = dynamic_cast<Enemy*>(obj);
+	if (enemy != nullptr)
+		return dynamic_cast<Enemy*>(obj);
+
+	Crystal* crystal = dynamic_cast<Crystal*>(obj);
+	if (crystal != nullptr)
+		return dynamic_cast<Crystal*>(obj);
 }
 
 bool Sword::collision(CollidableObject* with, bool begin, Direction fromDir)
@@ -54,6 +60,7 @@ bool Sword::collision(CollidableObject* with, bool begin, Direction fromDir)
 	Enemy* enemy = dynamic_cast<Enemy*>(with);
 	if (enemy)
 		enemy->smash();
+	
 
 	return true;
 }


### PR DESCRIPTION
Le piattaforme ora non rilevano le collisioni dai lati, quindi possono essere attraversate pure dai lati, è più bello da vedere.

Sistemate le collisioni con la spada, ora la spada può collidere anche con gli oggetti di tipo crystal